### PR TITLE
fix: improve default name to avoid same key in the list after delete

### DIFF
--- a/screens/form-builder/index.tsx
+++ b/screens/form-builder/index.tsx
@@ -25,7 +25,7 @@ export default function FormBuilder() {
       label: `New ${type}`,
       value: '',
       checked: true,
-      name: `name_${formFields.length + 1}`, // Set default name
+      name: `name_${Math.random().toString().slice(-10)}`, // Set default name
       placeholder: 'Enter Placeholder',
       description: '',
       required: true,


### PR DESCRIPTION
Hey, I noticed a bug in the form builder.

-> If you delete an input field from the middle of the list and then add a new one, two items end up with the same key, and it stops working properly.

Maybe using crypto.randomUUID() would be better for unique keys, but since you're using names, this might look cleaner.


