### PR TITLE
fix: json tab text is not visible on dark mode

### DIFF
--- a/screens/form-preview/index.tsx
+++ b/screens/form-preview/index.tsx
@@ -152,7 +152,7 @@ export const FormPreview: React.FC<FormPreviewProps> = ({ formFields }) => {
           <If
             condition={formFields.length > 0}
             render={() => (
-              <pre className="p-4 text-sm bg-gray-100 rounded-lg h-full md:max-h-[70vh] overflow-auto">
+              <pre className="p-4 text-sm bg-secondary rounded-lg h-full md:max-h-[70vh] overflow-auto">
                 {JSON.stringify(formFields, null, 2)}
               </pre>
             )}


### PR DESCRIPTION
## Description
Fixed styling on json tab

## Screenshots

### Light Mode
![image](https://github.com/user-attachments/assets/0b9d5c75-cb8a-4c12-b124-dfce90666f33)

### Dark Mode
![image](https://github.com/user-attachments/assets/bd78663a-0867-4022-9f87-19ade96858a4)

closes #33 