### PR TITLE
Fix incorrect svg props for SmileIcon

### DIFF
--- a/components/smile.tsx
+++ b/components/smile.tsx
@@ -34,9 +34,9 @@ const SmileIcon = () => {
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       >
         <circle cx="12" cy="12" r="10" />
         <motion.path


### PR DESCRIPTION
This PR aims to fix the SVG Props which throw an error due to incorrect camelCasing which is needed in React.

![image](https://github.com/user-attachments/assets/85a6a616-9e66-4e44-8177-550b42429742)

P.S: This package is super useful and I've been loving it. Thanks for the efforts!!!
