### PR TITLE
Fix popover width to match the parent trigger width

### DIFF
--- a/components/ui/location-input.tsx
+++ b/components/ui/location-input.tsx
@@ -129,7 +129,7 @@ const LocationSelector = ({
             <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[300px] p-0">
+        <PopoverContent className="p-0">
           <Command>
             <CommandInput placeholder="Search country..." />
             <CommandList>
@@ -187,7 +187,7 @@ const LocationSelector = ({
               <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className="w-[300px] p-0">
+          <PopoverContent className="p-0">
             <Command>
               <CommandInput placeholder="Search state..." />
               <CommandList>

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-[--radix-popover-trigger-width] max-h-[--radix-popover-content-available-height]',
         className,
       )}
       {...props}

--- a/screens/render-form-field/index.tsx
+++ b/screens/render-form-field/index.tsx
@@ -181,7 +181,7 @@ export const renderFormField = (field: FormFieldType, form: any) => {
                 </Button>
               </FormControl>
             </PopoverTrigger>
-            <PopoverContent className="w-[200px] p-0">
+            <PopoverContent className="p-0">
               <Command>
                 <CommandInput placeholder="Search language..." />
                 <CommandList>
@@ -558,10 +558,10 @@ export const renderFormField = (field: FormFieldType, form: any) => {
         <FormItem>
           <FormLabel>{field.label}</FormLabel>
           <FormControl>
-            <PasswordInput 
+            <PasswordInput
               value={password}
-              placeholder='password'
-              onChange={(e:ChangeEvent<HTMLInputElement>)=>{
+              placeholder="password"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 setPassword(e.target.value)
                 form.setValue(field.name, e.target.value, {
                   shouldValidate: true,
@@ -579,15 +579,15 @@ export const renderFormField = (field: FormFieldType, form: any) => {
         <FormItem>
           <FormLabel>{field.label}</FormLabel>
           <FormControl>
-
-            <PhoneInput 
-              defaultCountry="TR" 
-              onChange={(phoneNumber)=>{
-              form.setValue(field.name, phoneNumber, {
-                shouldValidate: true,
-                shouldDirty: true,
-              })
-            }}/>
+            <PhoneInput
+              defaultCountry="TR"
+              onChange={(phoneNumber) => {
+                form.setValue(field.name, phoneNumber, {
+                  shouldValidate: true,
+                  shouldDirty: true,
+                })
+              }}
+            />
           </FormControl>
           <FormDescription>{field.description}</FormDescription>
           <FormMessage />


### PR DESCRIPTION
### Overview
When a Popover component is used the PopoverContent width should by default take the trigger parent's width and the user should be able to configure if needed (by passing w-72, w-[200] etc..) 

This PR aims to add support to use the radix css variables to fix this. (Refer: [Radix Docs](https://www.radix-ui.com/primitives/docs/components/popover#constrain-the-content-size), [Shadcn Github Issue](https://github.com/shadcn-ui/ui/issues/1690))

### UI Changes

![image](https://github.com/user-attachments/assets/9c1db442-3c8d-4377-8edd-3be8424d9509)
