### PR TITLE
Add empty list SVG instead of PNG to support Dark mode

### DIFF
--- a/assets/oc-thinking.svg
+++ b/assets/oc-thinking.svg
@@ -1,0 +1,67 @@
+<svg width="343" height="251" viewBox="0 0 343 251" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M262.07 234.036C251.678 225.569 265.758 224.575 274.097 225.136V230.669L294.063 235.72C287.729 238.687 272.462 242.504 262.07 234.036Z" fill="currentColor"/>
+  <path d="M316.676 228.985C309.94 229.754 307.936 226.739 307.775 225.136H322.209C323.171 226.098 323.411 228.215 316.676 228.985Z" fill="currentColor"/>
+  <path d="M301.52 205.651C294.063 205.651 289.974 205.17 283.96 204.689" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M307.294 208.538V231.631" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M289.974 209.74L274.097 208.538" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M297.431 212.146V235.48" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M297.19 235.961L307.294 231.871" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M283.719 204.689L274.097 208.538" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M273.857 208.778V230.909" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M273.616 230.668L297.19 235.961" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M301.521 206.132V199.396" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M322.449 224.895V201.562" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M333.755 193.864V219.844" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M322.449 225.376L333.755 219.844" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M333.755 193.623L308.256 192.661" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M301.521 199.397L308.256 192.661" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M322.449 201.321L333.514 194.104" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M322.449 224.895H308.256" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M301.762 199.396L315.473 199.878" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M109.542 244.162C109.783 237.426 136.725 239.591 138.409 239.832V244.162L146.587 249.935C134.159 250.256 109.35 249.55 109.542 244.162Z" fill="currentColor"/>
+  <path d="M176.417 243.44V218.904" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M155.488 249.694V222.752" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M138.168 243.44V216.498" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M138.168 216.498L157.172 211.687" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M176.416 218.663L155.488 222.512" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M155.488 249.935L176.416 243.681" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M176.416 218.663L157.172 211.687" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M138.168 216.739L155.729 222.512" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M199.868 242.959C195.442 235.261 209.571 234.139 217.188 234.54V240.072L241.965 242.959C229.777 246.166 204.295 250.657 199.868 242.959Z" fill="currentColor"/>
+  <path d="M254.233 232.615L244.852 242.237" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M242.686 212.89L218.39 211.206" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M228.253 204.952L254.233 206.154" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M217.909 211.206L216.706 239.11" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M254.233 206.635V232.134" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M244.852 221.79V242.237" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M217.909 211.206L228.252 204.952" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M244.851 242.237L216.466 239.351" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M194.852 62.6709C195.895 62.35 198.653 62.0454 201.347 63.3925" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M185.229 75.1795C187.089 75.1795 188.597 73.564 188.597 71.5712C188.597 69.5784 187.089 67.9629 185.229 67.9629C183.369 67.9629 181.861 69.5784 181.861 71.5712C181.861 73.564 183.369 75.1795 185.229 75.1795Z" fill="currentColor"/>
+  <path d="M212.652 79.9905C214.512 79.9905 216.02 78.375 216.02 76.3822C216.02 74.3894 214.512 72.7739 212.652 72.7739C210.792 72.7739 209.285 74.3894 209.285 76.3822C209.285 78.375 210.792 79.9905 212.652 79.9905Z" fill="currentColor"/>
+  <path d="M177.051 65.7982C177.291 64.2746 178.783 61.3721 182.824 61.9494" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M207.842 65.3169C209.766 63.633 214.577 61.2756 218.426 65.3169" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M197.498 69.4062C199.743 73.0949 202.887 81.0009 197.498 83.1178L194.852 84.08" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M188.357 91.5371C188.919 93.0608 191.052 95.5784 195.093 93.4615" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M110.898 56.1759C103.008 82.1557 124.93 100.999 136.878 107.173C147.655 100.63 163.018 97.3105 169.593 96.3483C161.415 89.6128 158.929 77.2643 158.287 71.5713C153.957 73.0147 142.411 67.4819 147.703 56.1759C151.937 47.1311 156.523 51.7656 158.287 55.2137L170.075 60.5059C170.075 49.5367 177.612 45.8321 181.381 45.351C183.69 43.8115 186.192 38.7757 187.154 36.4506C188.308 45.4954 200.144 52.0865 205.917 54.2515C213.422 48.2858 219.468 51.7656 221.553 54.2515L226.845 53.5298C237.189 50.0019 255.76 37.942 247.292 17.9279C238.825 -2.08609 221.312 1.57032 213.615 5.90028C187.25 -11.612 160.773 13.9987 150.83 28.9934C140.807 27.2292 118.789 30.1962 110.898 56.1759Z" fill="currentColor"/>
+  <path d="M169.834 60.7467L158.288 54.7329" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M194.611 60.2656C194.611 68.5622 188.941 74.9393 182.343 74.9393C175.745 74.9393 170.075 68.5622 170.075 60.2656C170.075 51.9684 175.745 45.5918 182.343 45.5918C188.941 45.5918 194.611 51.9684 194.611 60.2656Z" stroke="currentColor" stroke-width="2"/>
+  <path d="M226.365 65.5575C226.365 73.8542 220.694 80.2313 214.096 80.2313C207.498 80.2313 201.828 73.8542 201.828 65.5575C201.828 57.2604 207.498 50.8838 214.096 50.8838C220.694 50.8838 226.365 57.2604 226.365 65.5575Z" stroke="currentColor" stroke-width="2"/>
+  <path d="M226.846 111.929C245.32 97.1111 234.784 77.1293 227.086 68.8701C222.853 88.8842 213.054 97.496 208.804 99.4204L215.54 103.029L226.846 111.929Z" fill="currentColor"/>
+  <path d="M159.731 60.2656C159.33 55.8553 154.198 45.3513 148.666 55.2139C146.26 59.7041 144.528 69.3104 156.844 71.8121" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M155.642 58.5815C154.519 59.5438 152.851 62.0455 155.16 64.3548" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M225.403 71.0903C224.055 78.788 221.072 85.7607 217.945 90.094C215.99 92.8036 212.822 96.2238 208.782 99.2052" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M158.047 71.812C157.887 81.5944 161.704 96.1079 179.216 103.806C181.91 104.99 184.559 105.669 187.133 105.943" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M207.12 115.593C203.271 114.63 199.583 117.758 198.219 119.442C197.498 120.965 197.161 123.964 201.587 123.772C207.12 123.531 208.804 115.593 215.299 128.342C220.495 138.541 220.832 158.571 220.35 167.312" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M194.528 112.947C193.273 115.673 192.254 120.789 198.219 119.442" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M196.849 103.565C193.481 105.008 188.597 110.204 190.522 113.668C190.762 114.069 191.484 114.823 192.446 114.63C192.867 114.546 193.554 113.813 194.528 112.947C196.333 111.34 199.123 109.279 203.03 110.06" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M264.166 186.166C266.571 174.379 264.227 146.72 234.784 120.163L215.299 103.084L203.031 96.589L200.626 96.1079L191.485 98.2729L190.522 99.2351L187.395 105.008C186.914 106.211 188.983 107.606 192.447 106.452" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M168.872 97.3105C153.236 99.3952 112.645 108.358 88.0464 144.7C64.8628 178.95 91.0831 193.383 110.568 194.104" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M1 198.915L109.489 193.623" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M139.078 192.42L341.215 183.614" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M121.058 194.474C121.355 195.396 121.136 196.059 119.978 196.159C116.549 196.453 112.477 191.138 110.87 188.443" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M121.049 184.034C122.761 186.768 125.745 190.981 128.361 193.372C128.123 195.208 126.328 198.001 121.058 194.474C120.256 191.984 115.692 187.609 115.692 187.341" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M125.692 181.463C128.966 185.076 134.908 192.816 132.479 194.873C132.048 195.237 131.499 195.273 130.872 195.059C130.124 194.804 129.265 194.197 128.361 193.372C125.745 190.982 122.761 186.769 121.049 184.034" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M98.7803 190.878C104.257 184.02 121.763 169.155 131.764 178.156C135.752 182.137 140.723 189.33 137.866 192.27C136.437 193.372 133.344 191.902 131.35 188.963" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M118.29 151.767C114.842 154.494 109.438 161.582 115.404 168.125" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/screens/form-builder/index.tsx
+++ b/screens/form-builder/index.tsx
@@ -14,8 +14,7 @@ import { FieldSelector } from '@/screens/field-selector'
 import { FormFieldList } from '@/screens/form-field-list'
 import { FormPreview } from '@/screens/form-preview'
 import { EditFieldDialog } from '@/screens/edit-field-dialog'
-
-import EmptyListImage from '@/assets/oc-thinking.png'
+import EmptyListSvg from '@/assets/oc-thinking.svg'
 
 export type FormFieldOrGroup = FormFieldType | FormFieldType[]
 
@@ -41,12 +40,12 @@ export default function FormBuilder() {
       disabled: false,
       label: label || newFieldName,
       name: newFieldName,
-      onChange: () => { },
-      onSelect: () => { },
+      onChange: () => {},
+      onSelect: () => {},
       placeholder: placeholder || 'Placeholder',
       required: true,
       rowIndex: index,
-      setValue: () => { },
+      setValue: () => {},
       type: '',
       value: '',
       variant,
@@ -162,13 +161,7 @@ export default function FormBuilder() {
                 addFormField(variant, index)
               }
             />
-            <Image
-              src={EmptyListImage}
-              width={585}
-              height={502}
-              alt="Empty Image"
-              className="object-contain mx-auto p-5 md:p-20"
-            />
+            <EmptyListSvg className="mx-auto" />
           </div>
         )}
       />


### PR DESCRIPTION
## Issue Fixed
This PR fixes the bug #36

## Overview
Previously the code was using a PNG to render the empty list scenario, due to which in dark mode it failed to look correct. Added an OCThinking SVG after fetching it from the [original creators](https://www.overflow.design/oc.html#pricingSection) to look good in both light and dark modes 

## UI Changes

### Before
![image](https://github.com/user-attachments/assets/ff9c694d-5ce9-4dda-96a2-0d32f4d4e734)

### After

![image](https://github.com/user-attachments/assets/d8415516-939a-4d5b-84c8-628e69158acf)
