### PR TITLE
fix: flag size and include additional improvements in phone input

### DIFF
--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -43,6 +43,7 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
           flagComponent={FlagComponent}
           countrySelectComponent={CountrySelect}
           inputComponent={InputComponent}
+          smartCaret={false}
           /**
            * Handles the onChange event.
            *

--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -115,9 +115,9 @@ const CountrySelect = ({
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0">
         <Command>
+          <CommandInput placeholder="Search country..." />
           <CommandList>
             <ScrollArea className="h-72">
-              <CommandInput placeholder="Search country..." />
               <CommandEmpty>No country found.</CommandEmpty>
               <CommandGroup>
                 {options

--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -159,7 +159,7 @@ const FlagComponent = ({ country, countryName }: RPNInput.FlagProps) => {
   const Flag = flags[country]
 
   return (
-    <span className="bg-foreground/20 flex h-4 w-6 overflow-hidden rounded-sm">
+    <span className="bg-foreground/20 flex h-4 w-6 overflow-hidden rounded-sm [&_svg]:size-full">
       {Flag && <Flag title={countryName} />}
     </span>
   )

--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -102,7 +102,7 @@ const CountrySelect = ({
         <Button
           type="button"
           variant={'outline'}
-          className={cn('flex gap-1 rounded-e-none rounded-s-lg px-3')}
+          className="flex gap-1 rounded-e-none rounded-s-lg border-r-0 px-3 focus:z-10"
           disabled={disabled}
         >
           <FlagComponent country={value} countryName={value} />


### PR DESCRIPTION
Fixes #41 

This PR focuses on fixing the issue where flags in the `PhoneInput` component appeared smaller than the container background. The solution involves adjusting the span wrapper styles for correct flag sizing.

Additionally, the following improvements are included:
- **Fix:** Reposition CommandInput (search) above CommandList to ensure correct behavior with fixed placement.
- **Fix:** Disable smart caret behavior to resolve cursor issues on mobile devices.
**Reference:** [PR #49](https://github.com/omeralpi/shadcn-phone-input/pull/49) from the shadcn-phone-input package.
- **Fix:** Update button styling by reducing the left border width from 2px to 1px for improved visual consistency.