### PR TITLE
fix: Add missing example code in the Form section (autocomplete, signature-input)

### DIFF
--- a/components/components/autocomplete-form.tsx
+++ b/components/components/autocomplete-form.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useRef } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'

--- a/components/components/autocomplete.tsx
+++ b/components/components/autocomplete.tsx
@@ -192,7 +192,70 @@ export default function Autocomplete({ value = '', onChange }: AutoCompleteProps
 
 const usageCode1 = `import Autocomplete from '@/components/ui/autocomplete'`
 
-const formCode = ``
+const formCode = `
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import Autocomplete from '@/components/ui/autocomplete'
+
+const FormSchema = z.object({
+  framework: z.string().min(1, 'Please select a framework'),
+})
+
+type AutocompleteFormData = z.infer<typeof FormSchema>
+
+export function AutocompleteForm() {
+  const form = useForm<AutocompleteFormData>({
+    resolver: zodResolver(FormSchema),
+  })
+
+  const onSubmit = (data: AutocompleteFormData) => {
+    console.log('HEY', data)
+    toast(
+      <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+        <code className="text-white">{JSON.stringify(data, null, 2)}</code>
+      </pre>,
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="framework"
+          render={({ field }) => (
+            <FormItem className="flex flex-col">
+              <div>
+                <FormLabel>What is your favorite framework?</FormLabel>
+              </div>
+              <Autocomplete value={field.value} onChange={field.onChange} />
+              <FormDescription>
+                Please type and select your favorite framework?
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  )
+}
+`
 
 export default function Component() {
   return (

--- a/components/components/signature-input.tsx
+++ b/components/components/signature-input.tsx
@@ -14,7 +14,8 @@ const code = `<SignatureInput
 
 const installationCode = `npx shadcn@latest add https://www.shadcn-form.com/registry/signature-input.json`
 
-const installationManuel = `'use client'
+const installationManuel = `
+'use client'
 
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -125,7 +126,75 @@ const usageCode2 = `<SignatureInput
   canvasRef={canvasRef}
   onSignatureChange={field.onChange}
 />`
-const formCode = ``
+const formCode = `
+'use client'
+
+import { useRef } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import SignatureInput from '@/components/ui/signature-input'
+
+const FormSchema = z.object({
+  signature: z.string().min(1, 'Please sign the form'),
+})
+
+type SignatureFormData = z.infer<typeof FormSchema>
+
+export function SignatureForm() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const form = useForm<SignatureFormData>({
+    resolver: zodResolver(FormSchema),
+  })
+
+  const onSubmit = (data: SignatureFormData) => {
+    // console.log('Signature Data URL:', data.signature)
+    toast(
+      <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+        <code className="text-white">{JSON.stringify(data, null, 2)}</code>
+      </pre>,
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="signature"
+          render={({ field }) => (
+            <FormItem className="flex flex-col">
+              <div>
+                <FormLabel>Sign here</FormLabel>
+              </div>
+              <SignatureInput
+                canvasRef={canvasRef}
+                onSignatureChange={field.onChange}
+              />
+              <FormDescription>
+                Please provide your signature above
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  )
+}
+`
 
 export default function Component() {
   const canvasRef = useRef<HTMLCanvasElement>(null)


### PR DESCRIPTION
Fix #43 

I added the missing example code to the Form sections of Autocompleteand and Signature Input components.