### PR TITLE
fix: input location getting old country value.

### DIFF
--- a/screens/generate-code-field/index.tsx
+++ b/screens/generate-code-field/index.tsx
@@ -229,7 +229,7 @@ export const generateCodeSnippet = (field: FormFieldType) => {
                     }}
                     onStateChange={(state) => {
                       setStateName(state?.name || '')
-                      form.setValue(field.name, [countryName || '', state?.name || ''])
+                      form.setValue(field.name, [form.getValues(field.name)[0] || '', state?.name || ''])
                     }}
                   />
                   </FormControl>

--- a/screens/render-form-field/index.tsx
+++ b/screens/render-form-field/index.tsx
@@ -367,7 +367,7 @@ export const renderFormField = (field: FormFieldType, form: any) => {
             }}
             onStateChange={(state) => {
               setStateName(state?.name || '')
-              form.setValue(field.name, [countryName || '', state?.name || ''])
+              form.setValue(field.name, [form.getValues(field.name)[0] || '', state?.name || ''])
             }}
           />
           <FormDescription>{field.description}</FormDescription>


### PR DESCRIPTION
### Issue
#28 - Empty string returned when selecting a country without states

### Problem Details
The input location is returning empty country when changing it, causing this issue on playground and when implementing it in an outside application.

### Fix
It now uses the country value of the form instead of the component's state.
As we have events from both country and state, it was getting the old value of country.