### PR TITLE
fix(playground): add missing Form import in RHF generated code

### DIFF
--- a/__tests__/generateReactHookFormCode.spec.ts
+++ b/__tests__/generateReactHookFormCode.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('generateReactHookFormCode', () => {
+  it('includes Form import when using <Form {...form}> wrapper', () => {
+    const filePath = resolve(
+      process.cwd(),
+      'screens/generate-code-parts/react-hook-form.tsx',
+    )
+    const code = readFileSync(filePath, 'utf8')
+
+    expect(code).toContain('import { Form } from "@/components/ui/form"')
+    expect(code).toContain('<Form {...form}>')
+  })
+})

--- a/screens/generate-code-parts/react-hook-form.tsx
+++ b/screens/generate-code-parts/react-hook-form.tsx
@@ -62,6 +62,7 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
 import { toast } from "sonner"
+import { Form } from "@/components/ui/form"
 import { Field, FieldLabel, FieldDescription, FieldError } from "@/components/ui/field"
 import { Button } from "@/components/ui/button"
 ${componentImports.join('\n')}`


### PR DESCRIPTION
## Summary
- add missing Form import to the React Hook Form playground code generator
- keep generated <Form {...form}> wrapper valid out of the box
- add regression test to ensure the import stays present

## Testing
- npm test -- --run

Fixes #100