### PR TITLE
[codex] Fix tweet entity crash

### DIFF
--- a/__tests__/normalizeTweetForReactTweet.spec.ts
+++ b/__tests__/normalizeTweetForReactTweet.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeTweetForReactTweet } from '../lib/tweet-utils'
+
+describe('normalizeTweetForReactTweet', () => {
+  it('fills missing tweet entity arrays before react-tweet enrichment', () => {
+    const tweet = {
+      entities: {
+        user_mentions: [],
+      },
+    }
+
+    const normalized = normalizeTweetForReactTweet(tweet as any)
+
+    expect(normalized.entities).toMatchObject({
+      hashtags: [],
+      urls: [],
+      user_mentions: [],
+      symbols: [],
+    })
+  })
+
+  it('also normalizes quoted tweet entities', () => {
+    const tweet = {
+      entities: {},
+      quoted_tweet: {
+        entities: {
+          urls: [],
+        },
+      },
+    }
+
+    const normalized = normalizeTweetForReactTweet(tweet as any)
+
+    expect(normalized.quoted_tweet?.entities).toMatchObject({
+      hashtags: [],
+      urls: [],
+      user_mentions: [],
+      symbols: [],
+    })
+  })
+})

--- a/components/magicui/tweet-card.tsx
+++ b/components/magicui/tweet-card.tsx
@@ -8,6 +8,7 @@ import {
 import { getTweet, type Tweet } from 'react-tweet/api'
 
 import { cn } from '@/lib/utils'
+import { normalizeTweetForReactTweet } from '@/lib/tweet-utils'
 
 interface TwitterIconProps {
   className?: string
@@ -230,7 +231,7 @@ export const MagicTweet = ({
   components?: TwitterComponents
   className?: string
 }) => {
-  const enrichedTweet = enrichTweet(tweet)
+  const enrichedTweet = enrichTweet(normalizeTweetForReactTweet(tweet))
   return (
     <div
       className={cn(

--- a/lib/tweet-utils.ts
+++ b/lib/tweet-utils.ts
@@ -1,0 +1,28 @@
+import type { Tweet } from 'react-tweet/api'
+
+type TweetLike = Tweet | NonNullable<Tweet['quoted_tweet']>
+
+const normalizeTweetEntities = <T extends TweetLike>(tweet: T): T => {
+  const entities = tweet.entities
+
+  return {
+    ...tweet,
+    entities: {
+      ...entities,
+      hashtags: Array.isArray(entities?.hashtags) ? entities.hashtags : [],
+      urls: Array.isArray(entities?.urls) ? entities.urls : [],
+      user_mentions: Array.isArray(entities?.user_mentions)
+        ? entities.user_mentions
+        : [],
+      symbols: Array.isArray(entities?.symbols) ? entities.symbols : [],
+      media: Array.isArray(entities?.media) ? entities.media : undefined,
+    },
+  }
+}
+
+export const normalizeTweetForReactTweet = (tweet: Tweet): Tweet => ({
+  ...normalizeTweetEntities(tweet),
+  quoted_tweet: tweet.quoted_tweet
+    ? normalizeTweetEntities(tweet.quoted_tweet)
+    : tweet.quoted_tweet,
+})


### PR DESCRIPTION
## Summary

Fixes the homepage client-side crash caused by tweet payloads from `react-tweet` missing entity arrays such as `symbols`, `urls`, or `hashtags`.

The tweet renderer now normalizes those optional entity collections to arrays before calling `enrichTweet`, including for quoted tweets. This prevents third-party tweet payload drift from taking down the whole page.

## Validation

- `npm test -- --run`
- `npm run build`
- Verified local production page no longer shows the generic `Application error` screen after `next start`.

## Notes

Two configured tweet IDs still return 404 from the third-party tweet API, but those render through the existing not-found path and are no longer fatal.
